### PR TITLE
requirements: add six to list of requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 scipy
 pyfftw
+six


### PR DESCRIPTION
The `six` python library is used in the LensIt code, but does not figure in the list of requirements.

LensIt is expecting `mpi4py` to be installed as well for better performance, which requires the libopenmpi-dev package to be installed on Debian-based Linux distributions, and the openmpi-devel package to be installed on RPM-based Linux distributions.
Maybe this can be added to the README, or to the requirements.txt as well ?